### PR TITLE
Tank

### DIFF
--- a/code/datums/ammo/bullet/tank.dm
+++ b/code/datums/ammo/bullet/tank.dm
@@ -87,7 +87,7 @@
 	accuracy_var_low = PROJECTILE_VARIANCE_TIER_8
 	accuracy_var_high = PROJECTILE_VARIANCE_TIER_8
 	accurate_range = 12
-	damage = 40
+	damage = 125
 	penetration = ARMOR_PENETRATION_TIER_6
 	damage_armor_punch = 1
 

--- a/code/datums/ammo/rocket.dm
+++ b/code/datums/ammo/rocket.dm
@@ -59,7 +59,7 @@
 	accuracy_var_low = PROJECTILE_VARIANCE_TIER_9
 	accurate_range = 6
 	max_range = 6
-	damage = 10
+	damage = 200
 	penetration= ARMOR_PENETRATION_TIER_10
 
 
@@ -163,7 +163,7 @@
 	accuracy = HIT_ACCURACY_TIER_3
 	accurate_range = 32
 	max_range = 32
-	damage = 200
+	damage = 300
 	shell_speed = AMMO_SPEED_TIER_3
 
 /datum/ammo/rocket/ltb/on_hit_mob(mob/mob, obj/projectile/projectile)

--- a/code/modules/cm_marines/dropship_ammo.dm
+++ b/code/modules/cm_marines/dropship_ammo.dm
@@ -137,6 +137,7 @@
 	name = "\improper 25mm multipurpose ammunition crate"
 	icon_state = "30mm_crate"
 	desc = "A 400rnd reinforced crate of Armor Piercing High Explosive and Incendiary 25mm ammunition for use with the GAU-113 rotary autocannon. Best used against light structures, personnel in the open, or thinskin vehicles. Entirely ineffective against heavier armor."
+	travelling_time = 50
 	equipment_type = /obj/structure/dropship_equipment/weapon/heavygun
 	ammo_count = 400
 	max_ammo_count = 400
@@ -144,10 +145,10 @@
 	ammo_used_per_firing = 40
 	point_cost = 275
 	fire_mission_delay = 2
-	var/bullet_spread_range = 3 //how far from the real impact turf can bullets land
+	var/bullet_spread_range = 2 //how far from the real impact turf can bullets land
 	var/shrapnel_type = /datum/ammo/bullet/shrapnel/gau //For siming 30mm bullet impacts.
-	var/directhit_damage = 105 //how much damage is to be inflicted to a mob, this is here so that we can hit resting mobs.
-	var/penetration = 10 //AP value pretty much
+	var/directhit_damage = 150 //how much damage is to be inflicted to a mob, this is here so that we can hit resting mobs.
+	var/penetration = 15 //AP value pretty much
 
 /obj/structure/ship_ammo/heavygun/get_examine_text(mob/user)
 	. = ..()
@@ -199,11 +200,11 @@
 	ammo_count = 400
 	max_ammo_count = 400
 	ammo_used_per_firing = 40
-	bullet_spread_range = 4
+	bullet_spread_range = 3
 	point_cost = 325
 	fire_mission_delay = 2
 	shrapnel_type = /datum/ammo/bullet/shrapnel/gau/at
-	directhit_damage = 80 //how much damage is to be inflicted to a mob, this is here so that we can hit resting mobs.
+	directhit_damage = 100 //how much damage is to be inflicted to a mob, this is here so that we can hit resting mobs.
 	penetration = 40 //AP value pretty much
 
 //laser battery
@@ -391,7 +392,7 @@
 	ammo_count = 6
 	max_ammo_count = 6
 	ammo_name = "minirocket"
-	travelling_time = 80 //faster than 30mm cannon, slower than real rockets
+	travelling_time = 40 //faster than 30mm cannon, slower than real rockets
 	transferable_ammo = TRUE
 	point_cost = 300
 	fire_mission_delay = 3 //high cooldown

--- a/code/modules/vehicles/hardpoints/armor/ballistic.dm
+++ b/code/modules/vehicles/hardpoints/armor/ballistic.dm
@@ -7,7 +7,7 @@
 	disp_icon_state = "ballistic_armor"
 
 	type_multipliers = list(
-		"bullet" = 0.67,
-		"slash" = 0.67,
+		"bullet" = 0.87,
+		"slash" = 0.87,
 		"all" = 0.9
 	)

--- a/code/modules/vehicles/hardpoints/primary/autocannon.dm
+++ b/code/modules/vehicles/hardpoints/primary/autocannon.dm
@@ -25,7 +25,7 @@
 	gun_firemode_list = list(
 		GUN_FIREMODE_AUTOMATIC,
 	)
-	fire_delay = 0.7 SECONDS
+	fire_delay = 0.5 SECONDS
 
 /obj/item/hardpoint/primary/autocannon/set_bullet_traits()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request
This PR places the tank on the level of the AA apc, and movie like APC. Currently it changes the fire rate of the AC3-E Autocannon, increases the damage of the LTAA Minigun, increases the damage of the tow launcher, increases the damage of the LTB, and increases the slash and bullet resistance of ballistic armor. I have tested these changes on my own local server but I believe these balance changes needs further testing.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying. -->

# Explain why it's good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding, and may discourage maintainers from reviewing or merging your PR. This section is not strictly required for (non-controversial) fix PRs or backend PRs. -->
To illustrate the point of why I buffed the tank's equipment, have a look at this meme I created.
![image](https://github.com/user-attachments/assets/6c33528e-ae78-4f3a-af44-2f3e2fbf69d0)
Before I changed these values, the tow launcher only did 10 damage when compared to the AA VLS launcher which did 300. The LTAA did 45 damage each bullet which made it feel extremely weak for an AP minigun. I buffed the LTB cannon from 200 damage to 300 damage because it is only capable of doing area damage and bounces off targets.


# Testing Photographs and Procedure
My testing procedure consisted of me spawning a tank with the required equipment and spawning 1 crusher first and then 5 drones. For the TOW launcher it took 2 rockets to kill a crusher and one to kill a drone. The LTAA did admirably against a horde of drones with the increasing firerate turning the gun into a lawnmower. The autocannon was fine in terms of damage but fired extremely slowly. The LTB struggled to kill a crusher but did extremely well against a crowd of drones.

<details>
<summary>Screenshots & Videos</summary>



</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: Increased LTAA damage from 40 to 125
balance: Increased Tow Launcher damage from 10 to 200
balance: Increased LTB damage from 200 to 300
balance: Increased bullet and slash resistance of Ballistic armor to 0.87
balance: Changed Autocannon fire rate from 0.7 seconds to 0.5 seconds
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
